### PR TITLE
Resolve bug/Github-Issue-49: seaborn 패키지 오류 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,10 +8,9 @@ import numpy as np
 import logging  # 로깅 모듈 추가
 from matplotlib.animation import FuncAnimation
 import matplotlib.animation as animation
-
 try:
     import seaborn as sns
-    plt.style.use('seaborn')
+    plt.style.use('seaborn-v0_8')
 except ImportError:
     plt.style.use('default')  # matplotlib 기본 스타일 사용
 


### PR DESCRIPTION
- seaborn 오류 수정
https://github.com/sumannam/PyWSNSim/issues/49

오류 내용 :
OSError: 'seaborn' is not a valid package style, path of style file, URL of style file, or library style name (library styles are listed in style.available)

## 발생 원인

상위 matplotlib 버전 (3.6+) 사용으로 인한 오류 문제로 판단됩니다.

## 조치 내용

아래 코드를

```python
plt.style.use('seaborn')
```

다음과 같이 변경하여 해결하였습니다.

```python
plt.style.use('seaborn-v0_8')
```